### PR TITLE
Fix Anthropic model expectation of "citations" attribute in response

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -379,7 +379,7 @@ class Claude(Model):
                     else:
                         model_response.content += block.text
 
-                    if block.citations:
+                    if hasattr(block, 'citations') and block.citations:
                         model_response.citations = Citations(raw=block.citations, documents=[])
                         for citation in block.citations:
                             model_response.citations.documents.append(  # type: ignore


### PR DESCRIPTION
While building with agno and using Claude without citations feature, error arise: 'TextBlock' object has no attribute 'citations'. This commit fixes this error by checking if citations param exists.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #____)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
